### PR TITLE
only cancel runs with commits that don't match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ### Updates
 
+### -> 1.42.1
+
+* No longer use deprecated github-api API `gitHttpTransportUrl()` ([#772][#772])
+
+[#772]: https://github.com/jenkinsci/ghprb-plugin/pull/772
+
+### -> 1.42.0
+
+- SECURITY-805 fix
+
 ### -> 1.41.0
 
 * Fix for stale ghprbCommentBody values ([#504][#504])

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -43,7 +43,9 @@
 
     <!-- Checks whether files end with a new line.                        -->
     <!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
-    <module name="NewlineAtEndOfFile"/>
+    <module name="NewlineAtEndOfFile">
+        <property name="lineSeparator" value="lf" />
+    </module>
 
     <!-- Checks that property files contain the same keys.         -->
     <!-- See http://checkstyle.sf.net/config_misc.html#Translation -->

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>ghprb</artifactId>
     <name>GitHub Pull Request Builder</name>
-    <version>1.42.12-SNAPSHOT</version>
+    <version>1.42.14-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <url>https://wiki.jenkins-ci.org/display/JENKINS/GitHub+pull+request+builder+plugin</url>

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.90</version>
+            <version>1.92</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>ghprb</artifactId>
     <name>GitHub Pull Request Builder</name>
-    <version>1.42.1-SNAPSHOT</version>
+    <version>1.42.1</version>
     <packaging>hpi</packaging>
 
     <url>https://wiki.jenkins-ci.org/display/JENKINS/GitHub+pull+request+builder+plugin</url>
@@ -39,7 +39,7 @@
         <connection>scm:git:ssh://github.com/jenkinsci/ghprb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/ghprb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/ghprb-plugin</url>
-        <tag>HEAD</tag>
+        <tag>ghprb-1.42.1</tag>
     </scm>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>ghprb</artifactId>
     <name>GitHub Pull Request Builder</name>
-    <version>1.42.1</version>
+    <version>1.42.2-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <url>https://wiki.jenkins-ci.org/display/JENKINS/GitHub+pull+request+builder+plugin</url>
@@ -39,7 +39,7 @@
         <connection>scm:git:ssh://github.com/jenkinsci/ghprb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/ghprb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/ghprb-plugin</url>
-        <tag>ghprb-1.42.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <issueManagement>

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -719,7 +719,7 @@ public class GhprbPullRequest {
         String authorRepoGitUrl = "";
 
         if (prHead != null && prHead.getRepository() != null) {
-            authorRepoGitUrl = prHead.getRepository().gitHttpTransportUrl();
+            authorRepoGitUrl = prHead.getRepository().getHttpTransportUrl();
         }
         return authorRepoGitUrl;
     }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -466,7 +466,7 @@ public class GhprbPullRequest {
             }
 
             List<String> paths = new ArrayList<String>();
-            for (GHPullRequestFileDetail fileDetail : pr.listFiles()) {
+            for (GHPullRequestFileDetail fileDetail : pr.listFiles().withPageSize(100)) {
                 paths.add(fileDetail.getFilename());
             }
 

--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/build/GhprbCancelBuildsOnUpdate.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/build/GhprbCancelBuildsOnUpdate.java
@@ -92,7 +92,7 @@ public class GhprbCancelBuildsOnUpdate extends GhprbExtension implements
             if (cause.getPullID() == prId && cause.getCommit() != commit) {
                 try {
                     LOGGER.log(Level.FINER, "Cancelling running build #{1} of {2} for PR #{3} with commit {4}",
-                            new Object[] { run.getNumber(), project.getName(), cause.getPullID(), cause.getCommit() });
+                            new Object[] {run.getNumber(), project.getName(), cause.getPullID(), cause.getCommit()});
                     run.addAction(this);
                     run.getExecutor().interrupt(Result.ABORTED);
                 } catch (Exception e) {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/build/GhprbCancelBuildsOnUpdate.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/build/GhprbCancelBuildsOnUpdate.java
@@ -41,8 +41,7 @@ public class GhprbCancelBuildsOnUpdate extends GhprbExtension implements
         return overrideGlobal == null ? Boolean.valueOf(false) : overrideGlobal;
     }
 
-    protected void cancelCurrentBuilds(Job<?, ?> project,
-                                     Integer prId) {
+    protected void cancelCurrentBuilds(Job<?, ?> project, Integer prId, String commit) {
         if (getOverrideGlobal()) {
             return;
         }
@@ -65,7 +64,7 @@ public class GhprbCancelBuildsOnUpdate extends GhprbExtension implements
                         qcause = (GhprbCause) cause;
                     }
                 }
-                if (qcause != null && qcause.getPullID() == prId) {
+                if (qcause != null && qcause.getPullID() == prId && qcause.getCommit() != commit) {
                     try {
                         LOGGER.log(
                                 Level.FINER,
@@ -90,13 +89,10 @@ public class GhprbCancelBuildsOnUpdate extends GhprbExtension implements
             if (cause == null) {
                 continue;
             }
-            if (cause.getPullID() == prId) {
+            if (cause.getPullID() == prId && cause.getCommit() != commit) {
                 try {
-                    LOGGER.log(
-                            Level.FINER,
-                            "Cancelling running build #" + run.getNumber() + " of "
-                                    + project.getName() + " for PR # " + cause.getPullID()
-                    );
+                    LOGGER.log(Level.FINER, "Cancelling running build #{1} of {2} for PR #{3} with commit {4}",
+                            new Object[] { run.getNumber(), project.getName(), cause.getPullID(), cause.getCommit() });
                     run.addAction(this);
                     run.getExecutor().interrupt(Result.ABORTED);
                 } catch (Exception e) {
@@ -112,7 +108,7 @@ public class GhprbCancelBuildsOnUpdate extends GhprbExtension implements
             return;
         }
         if (project.isBuilding() || project.isInQueue()) {
-            cancelCurrentBuilds(project, cause.getPullID());
+            cancelCurrentBuilds(project, cause.getPullID(), cause.getCommit());
         }
     }
 

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestTest.java
@@ -218,7 +218,7 @@ public class GhprbPullRequestTest {
         // GIVEN
         String expectedAuthorRepoGitUrl = "https://github.com/jenkinsci/ghprb-plugin";
         GHRepository repository = mock(GHRepository.class);
-        given(repository.gitHttpTransportUrl()).willReturn(expectedAuthorRepoGitUrl);
+        given(repository.getHttpTransportUrl()).willReturn(expectedAuthorRepoGitUrl);
 
         given(head.getRepository()).willReturn(repository);
 

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestTest.java
@@ -92,6 +92,7 @@ public class GhprbPullRequestTest {
         @SuppressWarnings("unchecked")
         PagedIterator<GHPullRequestFileDetail> pagedIterator = mock(PagedIterator.class);
         given(pagedIterable.iterator()).willReturn(pagedIterator);
+        given(pagedIterable.withPageSize(100)).willReturn(pagedIterable);
         given(pr.listFiles()).willReturn(pagedIterable);
 
         // Create the list of file paths to return

--- a/src/test/java/org/jenkinsci/plugins/ghprb/extensions/build/GhprbCancelBuildsOnUpdateTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/extensions/build/GhprbCancelBuildsOnUpdateTest.java
@@ -40,6 +40,6 @@ public class GhprbCancelBuildsOnUpdateTest extends GhprbITBaseTestCase {
     @Test
     public void testCancelCurrentBuilds() {
         builds.build(ghprbPullRequest, ghUser, "");
-        gcbou.cancelCurrentBuilds(project, 1);
+        gcbou.cancelCurrentBuilds(project, 1, "abc123");
     }
 }


### PR DESCRIPTION
This PR will change the behavior of the feature "Cancel Build on Update"

Instead of cancelling runs (both running and queued) from just an existing PR, we also look to see if the commit is different. This way when users run individual fi tests on a single commit the runs won't kill each other, and after they make a new commit the new runs will only kills runs that were running against the previous commit (which we don't care about anymore).

Here it is working. The first two runs were ran on the same PR using auth_fi_tests, then I pushed a commit while they were running, and the two running jobs were cancelled as a new job was started.
![image](https://user-images.githubusercontent.com/41299660/82005868-80b47f80-9634-11ea-9132-49bd351a1364.png)

I've also tested kicking off the fi tests, letting some tests start and others sit in the queue trying to spin up nodes, then committed and reran. The tests got cancelled and the new job started as expected. Something I noticed is that if you cancel ECS jobs that are in the middle of provisioning they'll still popup on the jenkins UI and stay active in cluster for 5 minutes, which I believe is due to the `Container Cleanup Timeout` setting in the Cloud settings.

I don't think reducing this will help much; it's sort of an edge case that could have consequences if we make it too short.